### PR TITLE
Fix image uploads failing

### DIFF
--- a/common/src/main/java/net/conczin/immersive_paintings/util/ImageManipulations.java
+++ b/common/src/main/java/net/conczin/immersive_paintings/util/ImageManipulations.java
@@ -100,9 +100,10 @@ public class ImageManipulations {
                 );
 
                 // The thumbnail would not be smaller than the actual painting
+                // NOTE: This cannot be (int) casted because rounding errors can produce 0x0 images
                 if (z < 1.0f) {
-                    w *= (int) z;
-                    h *= (int) z;
+                    w *= z;
+                    h *= z;
                 }
 
                 // If the zoom didn't change, then the original image is small enough already


### PR DESCRIPTION
When resizing for thumbnails the width and height cannot be casted to integers before multiplying, because the zoom is typically a number `< 0.025`, and casting this results in a `0` and inevitably a `0x0` thumbnail image, which crashes the uploading process.